### PR TITLE
Update for 172

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 RUN \
  apt-get update && \ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,60 +7,61 @@ RUN \
 ENV ADMIN_USER admin
 
 ENV PAYARA_PATH /opt/payara41
-ENV DEPLOY_DIR $PAYARA_PATH/deployments
-ENV AUTODEPLOY_DIR $PAYARA_PATH/glassfish/domains/domain1/autodeploy
+ENV DEPLOY_DIR ${PAYARA_PATH}/deployments
+ENV PAYARA_DOMAIN domain1
+ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 
 RUN \ 
- mkdir -p $PAYARA_PATH/deployments && \
- useradd -b /opt -m -s /bin/bash -d $PAYARA_PATH payara && echo payara:payara | chpasswd
+ mkdir -p ${PAYARA_PATH}/deployments && \
+ useradd -b /opt -m -s /bin/bash -d ${PAYARA_PATH} payara && echo payara:payara | chpasswd
 
 # specify Payara version to download
 ENV PAYARA_PKG https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+4.1.2.172/payara-4.1.2.172.zip
 ENV PAYARA_VERSION 172
 
-ENV PKG_FILE_NAME payara-full-$PAYARA_VERSION.zip
+ENV PKG_FILE_NAME payara-full-${PAYARA_VERSION}.zip
 
 # Download Payara Server and install
 RUN \
- wget --quiet -O /opt/$PKG_FILE_NAME $PAYARA_PKG && \
- unzip -qq /opt/$PKG_FILE_NAME -d /opt && \
+ wget --quiet -O /opt/${PKG_FILE_NAME} ${PAYARA_PKG} && \
+ unzip -qq /opt/${PKG_FILE_NAME} -d /opt && \
  chown -R payara:payara /opt && \
  # cleanup
- rm /opt/$PKG_FILE_NAME
+ rm /opt/${PKG_FILE_NAME}
 
 USER payara
-WORKDIR $PAYARA_PATH
+WORKDIR ${PAYARA_PATH}
 
 # set credentials to admin/admin 
 
 ENV ADMIN_PASSWORD admin
 
 RUN echo 'AS_ADMIN_PASSWORD=\n\
-AS_ADMIN_NEWPASSWORD='$ADMIN_PASSWORD'\n\
+AS_ADMIN_NEWPASSWORD='${ADMIN_PASSWORD}'\n\
 EOF\n'\
 >> /opt/tmpfile
 
-RUN echo 'AS_ADMIN_PASSWORD='$ADMIN_PASSWORD'\n\
+RUN echo 'AS_ADMIN_PASSWORD='${ADMIN_PASSWORD}'\n\
 EOF\n'\
 >> /opt/pwdfile
 
 RUN \
- $PAYARA_PATH/bin/asadmin start-domain && \
- $PAYARA_PATH/bin/asadmin --user $ADMIN_USER --passwordfile=/opt/tmpfile change-admin-password && \
- $PAYARA_PATH/bin/asadmin --user $ADMIN_USER --passwordfile=/opt/pwdfile enable-secure-admin && \
- $PAYARA_PATH/bin/asadmin stop-domain && \
+ ${PAYARA_PATH}/bin/asadmin start-domain ${PAYARA_DOMAIN} && \
+ ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password && \
+ ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/pwdfile enable-secure-admin && \
+ ${PAYARA_PATH}/bin/asadmin stop-domain && \
 # cleanup
  rm /opt/tmpfile
 
 # Default payara ports to expose
 EXPOSE 4848 8009 8080 8181
 
-ENV DEPLOY_COMMANDS=$PAYARA_PATH/post-boot-commands.asadmin
-COPY generate_deploy_commands.sh $PAYARA_PATH/generate_deploy_commands.sh
+ENV DEPLOY_COMMANDS=${PAYARA_PATH}/post-boot-commands.asadmin
+COPY generate_deploy_commands.sh ${PAYARA_PATH}/generate_deploy_commands.sh
 USER root
 RUN \
- chown -R payara:payara $PAYARA_PATH/generate_deploy_commands.sh && \
- chmod a+x $PAYARA_PATH/generate_deploy_commands.sh
+ chown -R payara:payara ${PAYARA_PATH}/generate_deploy_commands.sh && \
+ chmod a+x ${PAYARA_PATH}/generate_deploy_commands.sh
 USER payara
 
-ENTRYPOINT $PAYARA_PATH/generate_deploy_commands.sh && $PAYARA_PATH/bin/asadmin start-domain -v --postbootcommandfile $DEPLOY_COMMANDS
+ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/asadmin start-domain -v --postbootcommandfile ${DEPLOY_COMMANDS}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,39 @@
 FROM java:8-jdk
 
-ENV PAYARA_PKG https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+4.1.1.171.0.1/payara-4.1.1.171.0.1.zip
-ENV PAYARA_VERSION 171
-ENV PKG_FILE_NAME payara-full-$PAYARA_VERSION.zip
-ENV PAYARA_PATH /opt/payara41
-ENV ADMIN_USER admin
-ENV ADMIN_PASSWORD admin
-
-
 RUN \
  apt-get update && \ 
  apt-get install -y unzip 
 
-RUN wget --quiet -O /opt/$PKG_FILE_NAME $PAYARA_PKG
-RUN unzip -qq /opt/$PKG_FILE_NAME -d /opt
+ENV ADMIN_USER admin
 
-RUN mkdir -p $PAYARA_PATH/deployments
-RUN useradd -b /opt -m -s /bin/bash -d $PAYARA_PATH payara && echo payara:payara | chpasswd
-RUN chown -R payara:payara /opt
+ENV PAYARA_PATH /opt/payara41
+ENV DEPLOY_DIR $PAYARA_PATH/deployments
+ENV AUTODEPLOY_DIR $PAYARA_PATH/glassfish/domains/domain1/autodeploy
 
-# Default payara ports to expose
-EXPOSE 4848 8009 8080 8181
+RUN \ 
+ mkdir -p $PAYARA_PATH/deployments && \
+ useradd -b /opt -m -s /bin/bash -d $PAYARA_PATH payara && echo payara:payara | chpasswd
+
+# specify Payara version to download
+ENV PAYARA_PKG https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+4.1.2.172/payara-4.1.2.172.zip
+ENV PAYARA_VERSION 172
+
+ENV PKG_FILE_NAME payara-full-$PAYARA_VERSION.zip
+
+# Download Payara Server and install
+RUN \
+ wget --quiet -O /opt/$PKG_FILE_NAME $PAYARA_PKG && \
+ unzip -qq /opt/$PKG_FILE_NAME -d /opt && \
+ chown -R payara:payara /opt && \
+ # cleanup
+ rm /opt/$PKG_FILE_NAME
 
 USER payara
 WORKDIR $PAYARA_PATH
 
-
 # set credentials to admin/admin 
+
+ENV ADMIN_PASSWORD admin
 
 RUN echo 'AS_ADMIN_PASSWORD=\n\
 AS_ADMIN_NEWPASSWORD='$ADMIN_PASSWORD'\n\
@@ -41,8 +48,19 @@ RUN \
  $PAYARA_PATH/bin/asadmin start-domain && \
  $PAYARA_PATH/bin/asadmin --user $ADMIN_USER --passwordfile=/opt/tmpfile change-admin-password && \
  $PAYARA_PATH/bin/asadmin --user $ADMIN_USER --passwordfile=/opt/pwdfile enable-secure-admin && \
- $PAYARA_PATH/bin/asadmin restart-domain
-
+ $PAYARA_PATH/bin/asadmin stop-domain && \
 # cleanup
-RUN rm /opt/tmpfile
-RUN rm /opt/$PKG_FILE_NAME
+ rm /opt/tmpfile
+
+# Default payara ports to expose
+EXPOSE 4848 8009 8080 8181
+
+ENV DEPLOY_COMMANDS=$PAYARA_PATH/post-boot-commands.asadmin
+COPY generate_deploy_commands.sh $PAYARA_PATH/generate_deploy_commands.sh
+USER root
+RUN \
+ chown -R payara:payara $PAYARA_PATH/generate_deploy_commands.sh && \
+ chmod a+x $PAYARA_PATH/generate_deploy_commands.sh
+USER payara
+
+ENTRYPOINT $PAYARA_PATH/generate_deploy_commands.sh && $PAYARA_PATH/bin/asadmin start-domain -v --postbootcommandfile $DEPLOY_COMMANDS

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN \
 ENV ADMIN_USER admin
 
 ENV PAYARA_PATH /opt/payara41
-ENV DEPLOY_DIR ${PAYARA_PATH}/deployments
-ENV PAYARA_DOMAIN domain1
-ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 
 RUN \ 
  mkdir -p ${PAYARA_PATH}/deployments && \
@@ -45,13 +42,22 @@ RUN echo 'AS_ADMIN_PASSWORD='${ADMIN_PASSWORD}'\n\
 EOF\n'\
 >> /opt/pwdfile
 
+ # domain1
+RUN ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password
+
+ # payaradomain
 RUN \
- ${PAYARA_PATH}/bin/asadmin start-domain ${PAYARA_DOMAIN} && \
- ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password && \
+ ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password --domain_name=payaradomain && \
+ ${PAYARA_PATH}/bin/asadmin start-domain payaradomain && \
  ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/pwdfile enable-secure-admin && \
- ${PAYARA_PATH}/bin/asadmin stop-domain && \
+ ${PAYARA_PATH}/bin/asadmin stop-domain payaradomain
+
 # cleanup
- rm /opt/tmpfile
+RUN rm /opt/tmpfile
+
+ENV PAYARA_DOMAIN domain1
+ENV DEPLOY_DIR ${PAYARA_PATH}/deployments
+ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 
 # Default payara ports to expose
 EXPOSE 4848 8009 8080 8181

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,4 @@ RUN \
  chmod a+x ${PAYARA_PATH}/generate_deploy_commands.sh
 USER payara
 
-ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/asadmin start-domain -v --postbootcommandfile ${DEPLOY_COMMANDS}
+ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/asadmin start-domain -v --postbootcommandfile ${DEPLOY_COMMANDS} ${PAYARA_DOMAIN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,10 @@ EOF\n'\
 >> /opt/pwdfile
 
  # domain1
-RUN ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password
+RUN ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password && \
+ ${PAYARA_PATH}/bin/asadmin start-domain domain1 && \
+ ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/pwdfile enable-secure-admin && \
+ ${PAYARA_PATH}/bin/asadmin stop-domain domain1
 
  # payaradomain
 RUN \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ However, deploying applications using the autodeployment directory is discourage
  - it requires a writable filesystem, what might be cumbersome when deploying from a mounted directory
  - this functionality is disabled in the `payaradomain` domain for security reasons and has to be enabled before using it with that domain
 
+## Selection of domain
+
+The default entry point starts the server in the `domain1` domain. If you want to start it with a different domain, e.g. `payaradomain`, you may provide the domain name in the `PAYARA_DOMAIN` environment variable. The following would start Payara Server in `payaradomain`, without changing the entry point:
+
+```
+docker run -p 8080:8080 --env PAYARA_DOMAIN=payaradomain payara/server-full
+```
+
+If you also want to use the `AUTODEPLOY_DIR` variable (although this is discouraged), you need to overwrite the value of this variable accordingly. It points to the autodeploy directory of the `domain1` domain by default.
+
 
 # Details
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ To boot and export admin interface on port 4848 (and also the default HTTP liste
 docker run -p 4848:4848 -p 8080:8080 payara/server-full
 ```
 
-The admin interface is secured by default, accessible using HTTPS on the host machine: [https://localhost:4848](https://localhost:4848) The default user and password is `admin`.
+In the default `domain1` domain, the admin interface is not secured, accessible using HTTP on the host machine: [http://localhost:4848](http://localhost:4848).
+
+In the `payaradomain`, the admin interface is secured by default, accessible using HTTPS on the host machine: [https://localhost:4848](https://localhost:4848).
+
+The default user and password is `admin` in both domains.
 
 ## Application deployment
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Once admin port is exposed, it is possible to deploy applications remotely, outs
 
 ### Deployment on startup
 
-Payara Server automatically deploys all deployable files in the `autodeploy` directory of the current domain. For example `/opt/payara41/glassfish/domains/domain1/autodeploy` in the default domain `domain1`.
+By default, Payara server automatically deploys all deployable files in the directory specified by the `AUTODEPLOY_DIR` environment variable (it refers to the `autodeploy` directory in the default domain `domain1`). If you use the default domain (`domain1`),  For example `/opt/payara41/glassfish/domains/domain1/autodeploy` in the default domain `domain1`.
 
 You can mount this folder as a docker volume to a directory, which contains your applications. The following will run Payara Server in the docker and will start applications that exist in the directory `~/payara/apps` on the local file-system:
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Updated repository for Payara Dockerfiles. This repository is for the **Full Pro
 To boot the default domain with HTTP listener exported on port 8080:
 
 ```
-docker run -p 8080:8080 payara/server-full bin/asadmin start-domain -v
+docker run -p 8080:8080 payara/server-full
 ```
+
+The Docker container specifies the default entry point, which starts the default domain `domain1` in foreground so that Payara Server becomes the main process.
 
 ## Open ports
 
@@ -28,10 +30,10 @@ Most common default open ports that can be exposed outside of the container:
 
 ## Administration
 
-To boot and export admin interface on port 4848:
+To boot and export admin interface on port 4848 (and also the default HTTP listener on port 8080):
 
 ```
-docker run -p 4848:4848 payara/server-full bin/asadmin start-domain -v
+docker run -p 4848:4848 -p 8080:8080 payara/server-full
 ```
 
 The admin interface is secured by default, accessible using HTTPS on the host machine: [https://localhost:4848](https://localhost:4848) The default user and password is `admin`.
@@ -44,25 +46,52 @@ Once admin port is exposed, it is possible to deploy applications remotely, outs
 
 ### Deployment on startup
 
-By default, Payara server automatically deploys all deployable files in the directory specified by the `AUTODEPLOY_DIR` environment variable (it refers to the `autodeploy` directory in the default domain `domain1`). If you use the default domain (`domain1`),  For example `/opt/payara41/glassfish/domains/domain1/autodeploy` in the default domain `domain1`.
+The docker image supports 2 ways of deploying applications on server startup.
 
-You can mount this folder as a docker volume to a directory, which contains your applications. The following will run Payara Server in the docker and will start applications that exist in the directory `~/payara/apps` on the local file-system:
+#### Deployment on startup using a startup script
 
-```
-docker run -p 8080:8080 \
- -v ~/payara/apps:/opt/payara41/glassfish/domains/domain1/autodeploy \
- payara/server-full bin/asadmin start-domain -v
-```
+Since version 172, Payara Server supports running asadmin commands automatically after the domain is started, including the deploy command to deploy applications. This is the preferred way to deploy applications on Docker container startup.
 
-Another approach is to extend the docker image to add your deployables into the `autodeploy` directory and run the resulting docker image instead of the original one.
+The default Docker entry point will scan the folder `$DEPLOY_DIR` for files and folders and deploy them automatically after the domain is started.
 
-The following example Dockerfile will build an image that deploys `myapplication.war` when Payara Server domain `domain1` is started:
+In order to deploy applications, you can mount the `$DEPLOY_DIR` (`/opt/payara41/deployments`) folder as a docker volume to a directory, which contains your applications. The following will run Payara Server in the docker and will start applications that exist in the directory `~/payara/apps` on the local file-system:
 
 ```
-FROM payara/server-full:162
-
-COPY myapplication.war /opt/payara41/glassfish/domains/domain1/autodeploy
+docker run -p 8080:8080 -v ~/payara/apps:/opt/payara41/deployments payara/server-full
 ```
+
+In order to build a Docker image that contains your applications and starts them automatically, you can copy the applications into the `$DEPLOY_DIR` directory. and run the resulting docker image instead of the original one.
+
+The following example Dockerfile will build an image that starts Payara Server and deploys `myapplication.war` when the Docker container is started:
+
+```
+FROM payara/server-full
+
+COPY myapplication.war $DEPLOY_DIR
+```
+
+You can now build the Docker image and run the application `myapplication.war` with the following commands:
+
+```
+docker build -t mycompany/myapplication .
+```
+
+```
+docker run -p 8080:8080 mycompany/myapplication
+```
+
+#### Deployment on startup using the autodeployment directory
+
+When running the `domain1` domain, Payara server automatically deploys all deployable files in the directory specified by the `$AUTODEPLOY_DIR` environment variable (it refers to the `autodeploy` directory in the domain directory of `domain1`). 
+
+You can deploy applications in the same way as with the `$DEPLOY_DIR` directory as described above.
+
+However, deploying applications using the autodeployment directory is discouraged because of many drawbacks:
+
+ - this approach uses only default deployment options, it's not possible to define any deploy parameters, e.g. the context root and more
+ - it requires a writable filesystem, what might be cumbersome when deploying from a mounted directory
+ - this functionality is disabled in the `payaradomain` domain for security reasons and has to be enabled before using it with that domain
+
 
 # Details
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,7 @@ To boot and export admin interface on port 4848 (and also the default HTTP liste
 docker run -p 4848:4848 -p 8080:8080 payara/server-full
 ```
 
-In the default `domain1` domain, the admin interface is not secured, accessible using HTTP on the host machine: [http://localhost:4848](http://localhost:4848).
-
-In the `payaradomain`, the admin interface is secured by default, accessible using HTTPS on the host machine: [https://localhost:4848](https://localhost:4848).
-
-The default user and password is `admin` in both domains.
+Because Payara Server doesn't allow insecure remote admin connections (outside of a Docker container), the admin interface is secured by default (in both the default `domain1` as well as `payaradomain`), accessible using HTTPS on the host machine: [https://localhost:4848](https://localhost:4848) The default user and password is `admin`.
 
 ## Application deployment
 

--- a/generate_deploy_commands.sh
+++ b/generate_deploy_commands.sh
@@ -1,0 +1,10 @@
+if [ x$1 != x ]
+  then
+    DEPLOY_OPTS="$*"
+fi
+
+echo '# deployments after boot' > $POST_BOOT_COMMANDS
+for deployment in "${DEPLOY_DIR}"/*
+  do
+    echo "deploy --force --enabled=true $DEPLOY_OPTS $deployment" >> $DEPLOY_COMMANDS
+done

--- a/generate_deploy_commands.sh
+++ b/generate_deploy_commands.sh
@@ -1,9 +1,29 @@
+################################################################################
+#
+# A script to generate the $DEPLOY_COMMANDS file with asadmin commands to deploy 
+# all applications in $DEPLOY_DIR (either files or folders). 
+# The $DEPLOY_COMMANDS file can then be used with the start-domain using the
+#  --postbootcommandfile parameter to deploy applications on startup.
+#
+# Usage:
+# ./generate_deploy_commands.sh [deploy command parameters]
+#
+# Optionally, any number of parameters of the asadmin deploy command can be 
+# specified as parameters to this script. 
+# E.g., to deploy applications with implicit CDI scanning disabled:
+#
+# ./generate_deploy_commands.sh --properties=implicitCdiEnabled=false
+#
+# Note that many parameters to the deploy command can be safely used only when 
+# a single application exists in the $DEPLOY_DIR directory.
+################################################################################
+
 if [ x$1 != x ]
   then
     DEPLOY_OPTS="$*"
 fi
 
-echo '# deployments after boot' > $POST_BOOT_COMMANDS
+echo '# deployments after boot' > $DEPLOY_COMMANDS
 for deployment in "${DEPLOY_DIR}"/*
   do
     echo "deploy --force --enabled=true $DEPLOY_OPTS $deployment" >> $DEPLOY_COMMANDS


### PR DESCRIPTION
- updates the server to 172.
- refactoring to require fewer things to rebuild by Docker after each Payara release
- uses post-boot command to deploy apps
- added default entry point to start the server and deploy apps automatically
- choose which domain is started with an env var
- based on openjdk image, as suggested in https://github.com/payara/docker-payaramicro/issues/7