### PR TITLE
EXPOSE port 9009 instead of 8009

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ ENV DEPLOY_DIR ${PAYARA_PATH}/deployments
 ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 
 # Default payara ports to expose
-EXPOSE 4848 8009 8080 8181
+EXPOSE 4848 9009 8080 8181
 
 ENV POSTBOOT_COMMANDS ${PAYARA_PATH}/post-boot-commands.asadmin
 


### PR DESCRIPTION
I think this is a typo.
Payara listens at port 9009, not 8009 when debug is enabled.
Exposing via docker command line option "-P" does not expose debug port 9009.
Exposing the port via docker ("-p 9009:9009") works nonetheless, but this may lead to confusion.
Kind of niche, but still confusing. (Especially because I wanted to look up the debug port in the Dockerfile)

Or am I missing something else that is working on port 8009?