### PR TITLE
General cleanup and bug fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV HOME_DIR=/opt/payara\
 # Create and set the Payara user and working directory owned by the new user
 RUN groupadd payara && \
     useradd -b ${HOME_DIR} -M -s /bin/bash -d ${HOME_DIR} payara -g payara && \
+    echo payara:payara | chpasswd && \
     mkdir -p ${DEPLOY_DIR} && \
     mkdir -p ${CONFIG_DIR} && \
     mkdir -p ${SCRIPT_DIR} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ USER payara
 WORKDIR ${PAYARA_PATH}
 
 # Download and unzip the Payara distribution
-RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/distributions/payara/5.183/payara-5.183.zip && \
+RUN wget --no-verbose -O payara.zip ${PAYARA_PKG} && \
     chown payara:payara payara.zip && \
     unzip -qq payara.zip -d ./ && \
     mv payara*/ appserver && \
@@ -42,11 +42,13 @@ RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile create-domain --template=appserver/glassfish/common/templates/gf/production-domain.jar ${DOMAIN_NAME} && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile start-domain ${DOMAIN_NAME} && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile enable-secure-admin && \
+    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile stop-domain ${DOMAIN_NAME} && \
     # Cleanup unused files
     rm -rf \
         payara.zip \
         appserver/glassfish/domains/${DOMAIN_NAME}/osgi-cache \
+        appserver/glassfish/domains/${DOMAIN_NAME}/logs \
         appserver/glassfish/domains/production \
         appserver/glassfish/domains/domain1 \
         appserver/glassfish/common/templates/gf

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PAYARA_PATH=/opt/payara\
     ADMIN_USER=admin\
     ADMIN_PASSWORD=admin \
     # Payara download link
-    PAYARA_PKG=https://search.maven.org/remotecontent?filepath=fish/payara/distributions/payara/5.183/payara-5.183.zip\
+    PAYARA_PKG=http://central.maven.org/maven2/fish/payara/distributions/payara/5.183/payara-5.183.zip\
     # Utility environment variables
     JVM_ARGS=\
     DEPLOY_PROPS=\

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,7 @@ RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/
         ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/osgi-cache \
         ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/logs \
         ${PAYARA_DIR}/glassfish/domains/production \
-        ${PAYARA_DIR}/glassfish/domains/domain1 \
-        ${PAYARA_DIR}/glassfish/common/templates/gf
+        ${PAYARA_DIR}/glassfish/domains/domain1
 
 # Copy across docker scripts
 COPY --chown=payara:payara bin/*.sh ${SCRIPT_DIR}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,26 @@
 FROM openjdk:8u171-jdk
 
-ENV ADMIN_USER=admin \
-# set credentials to admin/admin
+# Initialize the configurable environment variables
+ENV PAYARA_PATH=/opt/payara\
+    # Credentials for Payara
+    ADMIN_USER=admin\
     ADMIN_PASSWORD=admin \
-    PAYARA_PATH=/opt/payara5 \
-# specify Payara version to download
-    PAYARA_PKG=https://search.maven.org/remotecontent?filepath=fish/payara/distributions/payara/5.183/payara-5.183.zip \
-    PAYARA_VERSION=5.183
+    # Payara download link
+    PAYARA_PKG=https://search.maven.org/remotecontent?filepath=fish/payara/distributions/payara/5.183/payara-5.183.zip\
+    # Utility environment variables
+    JVM_ARGS=\
+    DEPLOY_PROPS=\
+    DEPLOY_DIR=/opt/payara/deployments\
+    POSTBOOT_COMMANDS=/opt/payara/post-boot-commands.asadmin\
+    AS_ADMIN_PATH=/opt/payara/appserver/bin/asadmin
 
-COPY generate_deploy_commands.sh ${PAYARA_PATH}/generate_deploy_commands.sh
-COPY bin/startInForeground.sh ${PAYARA_PATH}/bin/startInForeground.sh
-
-RUN \
- mkdir -p ${PAYARA_PATH}/deployments && \
-# add payara user
- useradd --home-dir ${PAYARA_PATH} -s /bin/bash -d ${PAYARA_PATH} payara && \
- echo payara:payara | chpasswd && \
- chmod a+x ${PAYARA_PATH}/generate_deploy_commands.sh && \
- chmod a+x ${PAYARA_PATH}/bin/startInForeground.sh && \
-# download Payara Server, install, then remove downloaded file
- wget --no-verbose -O /opt/payara-full.zip ${PAYARA_PKG} && \
- unzip -qq /opt/payara-full.zip -d /opt && \
- chown -R payara:payara /opt && \
- ln -s ${PAYARA_PATH} /opt/payara && \
- rm /opt/payara-full.zip
-
+# Create and set the Payara user and working directory owned by the new user
+RUN groupadd payara && \
+    useradd -b ${PAYARA_PATH} -M -s /bin/bash -d ${PAYARA_PATH} payara -g payara && \
+    mkdir -p ${DEPLOY_DIR} && \
+    chown -R payara:payara ${PAYARA_PATH}
 USER payara
 WORKDIR ${PAYARA_PATH}
-
-# set credentials to admin/admin for both domains
-RUN \
- echo "AS_ADMIN_PASSWORD=" > /opt/tmpfile && \
- echo "AS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" >> /opt/tmpfile && \
- echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" > /opt/pwdfile && \
-# domain1
- ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password && \
- ${PAYARA_PATH}/bin/asadmin start-domain domain1 && \
- ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/pwdfile enable-secure-admin && \
- ${PAYARA_PATH}/bin/asadmin stop-domain domain1 && \
- rm -rf ${PAYARA_PATH}/glassfish/domains/domain1/osgi-cache && \
-# production
- ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/tmpfile change-admin-password --domain_name=production && \
- ${PAYARA_PATH}/bin/asadmin start-domain production && \
- ${PAYARA_PATH}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/opt/pwdfile enable-secure-admin && \
- ${PAYARA_PATH}/bin/asadmin stop-domain production && \
- rm -rf ${PAYARA_PATH}/glassfish/domains/production/osgi-cache && \
- rm /opt/tmpfile
-
-ENV PAYARA_DOMAIN domain1
-ENV DEPLOY_DIR ${PAYARA_PATH}/deployments
-ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 
 # Default payara ports to expose
 # 4848: admin console
@@ -58,6 +29,34 @@ ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 # 8181: https
 EXPOSE 4848 9009 8080 8181
 
-ENV POSTBOOT_COMMANDS ${PAYARA_PATH}/post-boot-commands.asadmin
+# Download and unzip the Payara distribution
+RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/distributions/payara/5.183/payara-5.183.zip && \
+    chown payara:payara payara.zip && \
+    unzip -qq payara.zip -d ./ && \
+    mv payara*/ appserver && \
+    # Configure the password files for configuring Payara
+    echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" >> /tmp/tmpFile && \
+    echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> passwordFile && \
+    # Configure domain1
+    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=/tmp/tmpFile change-admin-password && \
+    appserver/bin/asadmin start-domain domain1 && \
+    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile enable-secure-admin && \
+    appserver/bin/asadmin stop-domain domain1 && \
+    rm -rf appserver/glassfish/domains/domain1/osgi-cache && \
+    # Configure production
+    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=/tmp/tmpFile change-admin-password --domain_name=production && \
+    appserver/bin/asadmin start-domain production && \
+    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile enable-secure-admin && \
+    appserver/bin/asadmin stop-domain production && \
+    rm -rf appserver/glassfish/domains/production/osgi-cache && \
+    # Cleanup unused files
+    rm payara.zip && \
+    rm /tmp/tmpFile
 
-ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/startInForeground.sh  --passwordfile=/opt/pwdfile --postbootcommandfile ${POSTBOOT_COMMANDS} ${PAYARA_DOMAIN}
+# Copy across docker scripts
+COPY --chown=payara:payara generate_deploy_commands.sh ${PAYARA_PATH}/generate_deploy_commands.sh
+COPY --chown=payara:payara bin/startInForeground.sh ${PAYARA_PATH}/bin/startInForeground.sh
+RUN chmod +x ${PAYARA_PATH}/generate_deploy_commands.sh && \
+    chmod +x ${PAYARA_PATH}/bin/startInForeground.sh
+
+ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/startInForeground.sh  --passwordfile=/opt/payara/passwordFile --postbootcommandfile ${POSTBOOT_COMMANDS} ${PAYARA_DOMAIN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/
 COPY --chown=payara:payara bin/*.sh ${SCRIPT_DIR}/
 RUN chmod +x ${SCRIPT_DIR}/*
 
-CMD ${SCRIPT_DIR}/generate_deploy_commands.sh && ${SCRIPT_DIR}/startInForeground.sh
+CMD ${SCRIPT_DIR}/generate_deploy_commands.sh && exec ${SCRIPT_DIR}/startInForeground.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/
     # Cleanup unused files
     rm -rf \
         payara.zip \
+        appserver/glassfish/domains/${DOMAIN_NAME}/osgi-cache \
         appserver/glassfish/domains/production \
         appserver/glassfish/domains/domain1 \
         appserver/glassfish/common/templates/gf

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN wget --no-verbose -O payara.zip ${PAYARA_PKG} && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile create-domain --template=appserver/glassfish/common/templates/gf/production-domain.jar ${DOMAIN_NAME} && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile start-domain ${DOMAIN_NAME} && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile enable-secure-admin && \
+    for MEMORY_JVM_OPTION in $(appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile list-jvm-options | grep "Xm[sx]"); do\
+        appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile delete-jvm-options $MEMORY_JVM_OPTION;\
+    done && \
+    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile create-jvm-options '-XX\:+UnlockExperimentalVMOptions:-XX\:+UseCGroupMemoryLimitForHeap' && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
     appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile stop-domain ${DOMAIN_NAME} && \
     # Cleanup unused files

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,18 @@ FROM openjdk:8u171-jdk
 EXPOSE 4848 9009 8080 8181
 
 # Initialize the configurable environment variables
-ENV PAYARA_PATH=/opt/payara\
+ENV HOME_DIR=/opt/payara\
+    PAYARA_DIR=/opt/payara/appserver\
+    SCRIPT_DIR=/opt/payara/scripts\
+    CONFIG_DIR=/opt/payara/config\
+    DEPLOY_DIR=/opt/payara/deployments\
+    PASSWORD_FILE=/opt/payara/passwordFile\
+    # Payara version
+    PAYARA_VERSION=5.183\
+    # Payara Server Domain options
     DOMAIN_NAME=docker-domain\
-    # Credentials for Payara
     ADMIN_USER=admin\
     ADMIN_PASSWORD=admin \
-    # Payara download link
-    PAYARA_PKG=http://central.maven.org/maven2/fish/payara/distributions/payara/5.183/payara-5.183.zip\
     # Utility environment variables
     JVM_ARGS=\
     DEPLOY_PROPS=\
@@ -23,42 +28,42 @@ ENV PAYARA_PATH=/opt/payara\
 
 # Create and set the Payara user and working directory owned by the new user
 RUN groupadd payara && \
-    useradd -b ${PAYARA_PATH} -M -s /bin/bash -d ${PAYARA_PATH} payara -g payara && \
-    mkdir -p ${PAYARA_PATH}/deployments && \
-    mkdir -p ${PAYARA_PATH}/config && \
-    mkdir -p ${PAYARA_PATH}/scripts && \
-    chown -R payara:payara ${PAYARA_PATH}
+    useradd -b ${HOME_DIR} -M -s /bin/bash -d ${HOME_DIR} payara -g payara && \
+    mkdir -p ${DEPLOY_DIR} && \
+    mkdir -p ${CONFIG_DIR} && \
+    mkdir -p ${SCRIPT_DIR} && \
+    chown -R payara:payara ${HOME_DIR}
 USER payara
-WORKDIR ${PAYARA_PATH}
+WORKDIR ${HOME_DIR}
 
 # Download and unzip the Payara distribution
-RUN wget --no-verbose -O payara.zip ${PAYARA_PKG} && \
+RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/distributions/payara/${PAYARA_VERSION}/payara-${PAYARA_VERSION}.zip && \
     chown payara:payara payara.zip && \
     unzip -qq payara.zip -d ./ && \
     mv payara*/ appserver && \
     # Configure the password file for configuring Payara
-    echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> passwordFile && \
+    echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> ${PASSWORD_FILE} && \
     # Create and configure a domain
-    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile create-domain --template=appserver/glassfish/common/templates/gf/production-domain.jar ${DOMAIN_NAME} && \
-    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile start-domain ${DOMAIN_NAME} && \
-    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile enable-secure-admin && \
-    for MEMORY_JVM_OPTION in $(appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile list-jvm-options | grep "Xm[sx]"); do\
-        appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile delete-jvm-options $MEMORY_JVM_OPTION;\
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-domain --template=${PAYARA_DIR}/glassfish/common/templates/gf/production-domain.jar ${DOMAIN_NAME} && \
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} && \
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin && \
+    for MEMORY_JVM_OPTION in $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]"); do\
+        ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} delete-jvm-options $MEMORY_JVM_OPTION;\
     done && \
-    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile create-jvm-options '-XX\:+UnlockExperimentalVMOptions:-XX\:+UseCGroupMemoryLimitForHeap' && \
-    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
-    appserver/bin/asadmin --user=${ADMIN_USER} --passwordfile=passwordFile stop-domain ${DOMAIN_NAME} && \
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options '-XX\:+UnlockExperimentalVMOptions:-XX\:+UseCGroupMemoryLimitForHeap' && \
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} && \
     # Cleanup unused files
     rm -rf \
         payara.zip \
-        appserver/glassfish/domains/${DOMAIN_NAME}/osgi-cache \
-        appserver/glassfish/domains/${DOMAIN_NAME}/logs \
-        appserver/glassfish/domains/production \
-        appserver/glassfish/domains/domain1 \
-        appserver/glassfish/common/templates/gf
+        ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/osgi-cache \
+        ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/logs \
+        ${PAYARA_DIR}/glassfish/domains/production \
+        ${PAYARA_DIR}/glassfish/domains/domain1 \
+        ${PAYARA_DIR}/glassfish/common/templates/gf
 
 # Copy across docker scripts
-COPY --chown=payara:payara bin/*.sh scripts/
-RUN chmod +x scripts/*
+COPY --chown=payara:payara bin/*.sh ${SCRIPT_DIR}/
+RUN chmod +x ${SCRIPT_DIR}/*
 
-CMD ${PAYARA_PATH}/scripts/generate_deploy_commands.sh && ${PAYARA_PATH}/scripts/startInForeground.sh
+CMD ${SCRIPT_DIR}/generate_deploy_commands.sh && ${SCRIPT_DIR}/startInForeground.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ RUN wget --no-verbose -O payara.zip ${PAYARA_PKG} && \
 COPY --chown=payara:payara bin/*.sh scripts/
 RUN chmod +x scripts/*
 
-CMD ${PAYARA_PATH}/scripts/generate_deploy_commands.sh && ${PAYARA_PATH}/scripts/startInForeground.sh  --passwordfile=/opt/payara/passwordFile --postbootcommandfile ${POSTBOOT_COMMANDS} ${PAYARA_DOMAIN}
+CMD ${PAYARA_PATH}/scripts/generate_deploy_commands.sh && ${PAYARA_PATH}/scripts/startInForeground.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM openjdk:8u171-jdk
 
+# Default payara ports to expose
+# 4848: admin console
+# 9009: debug port (JPDA)
+# 8080: http
+# 8181: https
+EXPOSE 4848 9009 8080 8181
+
 # Initialize the configurable environment variables
 ENV PAYARA_PATH=/opt/payara\
     # Credentials for Payara
@@ -22,13 +29,6 @@ RUN groupadd payara && \
     chown -R payara:payara ${PAYARA_PATH}
 USER payara
 WORKDIR ${PAYARA_PATH}
-
-# Default payara ports to expose
-# 4848: admin console
-# 9009: debug port (JPDA)
-# 8080: http
-# 8181: https
-EXPOSE 4848 9009 8080 8181
 
 # Download and unzip the Payara distribution
 RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/distributions/payara/5.183/payara-5.183.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV HOME_DIR=/opt/payara\
     CONFIG_DIR=/opt/payara/config\
     DEPLOY_DIR=/opt/payara/deployments\
     PASSWORD_FILE=/opt/payara/passwordFile\
-    # Payara version
+    # Payara version (5.183+)
     PAYARA_VERSION=5.183\
     # Payara Server Domain options
     DOMAIN_NAME=production\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM openjdk:8u171-jdk
 
 ENV ADMIN_USER=admin \
 # set credentials to admin/admin

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV HOME_DIR=/opt/payara\
     # Payara version
     PAYARA_VERSION=5.183\
     # Payara Server Domain options
-    DOMAIN_NAME=docker-domain\
+    DOMAIN_NAME=production\
     ADMIN_USER=admin\
     ADMIN_PASSWORD=admin \
     # Utility environment variables
@@ -42,9 +42,10 @@ RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/
     unzip -qq payara.zip -d ./ && \
     mv payara*/ appserver && \
     # Configure the password file for configuring Payara
+    echo "AS_ADMIN_PASSWORD=\nAS_ADMIN_NEWPASSWORD=${ADMIN_PASSWORD}" > /tmp/tmpfile && \	
     echo "AS_ADMIN_PASSWORD=${ADMIN_PASSWORD}" >> ${PASSWORD_FILE} && \
-    # Create and configure a domain
-    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-domain --template=${PAYARA_DIR}/glassfish/common/templates/gf/production-domain.jar ${DOMAIN_NAME} && \
+    # Configure the payara domain
+    ${PAYARA_DIR}/bin/asadmin --user ${ADMIN_USER} --passwordfile=/tmp/tmpfile change-admin-password --domain_name=${DOMAIN_NAME} && \
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME} && \
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} enable-secure-admin && \
     for MEMORY_JVM_OPTION in $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]"); do\
@@ -55,10 +56,10 @@ RUN wget --no-verbose -O payara.zip http://central.maven.org/maven2/fish/payara/
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} && \
     # Cleanup unused files
     rm -rf \
+        /tmp/tmpFile \
         payara.zip \
         ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/osgi-cache \
         ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/logs \
-        ${PAYARA_DIR}/glassfish/domains/production \
         ${PAYARA_DIR}/glassfish/domains/domain1
 
 # Copy across docker scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,15 @@ ENV PAYARA_PATH=/opt/payara\
     # Utility environment variables
     JVM_ARGS=\
     DEPLOY_PROPS=\
-    DEPLOY_DIR=/opt/payara/deployments\
-    POSTBOOT_COMMANDS=/opt/payara/scripts/post-boot-commands.asadmin\
-    PREBOOT_COMMANDS=/opt/payara/scripts/pre-boot-commands.asadmin\
-    AS_ADMIN_PATH=/opt/payara/appserver/bin/asadmin
+    POSTBOOT_COMMANDS=/opt/payara/config/post-boot-commands.asadmin\
+    PREBOOT_COMMANDS=/opt/payara/config/pre-boot-commands.asadmin
 
 # Create and set the Payara user and working directory owned by the new user
 RUN groupadd payara && \
     useradd -b ${PAYARA_PATH} -M -s /bin/bash -d ${PAYARA_PATH} payara -g payara && \
-    mkdir -p ${DEPLOY_DIR} && \
+    mkdir -p ${PAYARA_PATH}/deployments && \
+    mkdir -p ${PAYARA_PATH}/config && \
+    mkdir -p ${PAYARA_PATH}/scripts && \
     chown -R payara:payara ${PAYARA_PATH}
 USER payara
 WORKDIR ${PAYARA_PATH}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To boot the default domain with HTTP listener exported on port 8080:
 docker run -p 8080:8080 payara/server-full
 ```
 
-The Docker container specifies the default entry point, which starts the default domain `domain1` in foreground so that Payara Server becomes the main process.
+The Docker container specifies the default entry point, which starts a custom domain `docker-domain` in foreground so that Payara Server becomes the main process.
 
 ## Open ports
 
@@ -27,6 +27,7 @@ Most common default open ports that can be exposed outside of the container:
  - 8080 - HTTP listener
  - 8181 - HTTPS listener
  - 4848 - HTTPS admin listener
+ - 9009 - Debug port
 
 ## Administration
 
@@ -36,7 +37,7 @@ To boot and export admin interface on port 4848 (and also the default HTTP liste
 docker run -p 4848:4848 -p 8080:8080 payara/server-full
 ```
 
-Because Payara Server doesn't allow insecure remote admin connections (outside of a Docker container), the admin interface is secured by default (in both the default `domain1` as well as `payaradomain`), accessible using HTTPS on the host machine: [https://localhost:4848](https://localhost:4848) The default user and password is `admin`.
+Because Payara Server doesn't allow insecure remote admin connections (outside of a Docker container), the admin interface is secured by default, accessible using HTTPS on the host machine: [https://localhost:4848](https://localhost:4848) The default user and password is `admin`.
 
 ## Application deployment
 
@@ -80,39 +81,40 @@ docker build -t mycompany/myapplication .
 docker run -p 8080:8080 mycompany/myapplication
 ```
 
-#### Deployment on startup using the autodeployment directory
-
-When running the `domain1` domain, Payara server automatically deploys all deployable files in the directory specified by the `$AUTODEPLOY_DIR` environment variable (it refers to the `autodeploy` directory in the domain directory of `domain1`). 
-
-You can deploy applications in the same way as with the `$DEPLOY_DIR` directory as described above.
-
-However, deploying applications using the autodeployment directory is discouraged because of many drawbacks:
-
- - this approach uses only default deployment options, it's not possible to define any deploy parameters, e.g. the context root and more
- - it requires a writable filesystem, what might be cumbersome when deploying from a mounted directory
- - this functionality is disabled in the `payaradomain` domain for security reasons and has to be enabled before using it with that domain
-
-## Selection of domain
-
-The default entry point starts the server in the `domain1` domain. If you want to start it with a different domain, e.g. `payaradomain`, you may provide the domain name in the `PAYARA_DOMAIN` environment variable. The following would start Payara Server in `payaradomain`, without changing the entry point:
-
-```
-docker run -p 8080:8080 --env PAYARA_DOMAIN=payaradomain payara/server-full
-```
-
-If you also want to use the `AUTODEPLOY_DIR` variable (although this is discouraged), you need to overwrite the value of this variable accordingly. It points to the autodeploy directory of the `domain1` domain by default.
-
 ## The default Docker entry point
 
-The default entry point does the following:
+The default entry point is `/bin/bash` as per the docker default. The default `CMD` command runs the following scripts:
 
-- generates an asadmin script which deploys all applications found in the directory `/opt/payara/deployments`, as described in _"Deployment on startup using a startup script"_
-- starts the server using the `startInForeground.sh` startup script, which avoids running 2 JVM instances as opposed to the command `asadmin start-domain --verbose`
-- uses the generated asadmin as a post boot command file to deploy all found applications at server start
+- `${SCRIPTS_DIR}/generate_deploy_commands.sh`. This script outputs deploy commands to the post boot command file located at `$POSTBOOT_COMMANDS` (default `$CONFIG_DIR/post-boot-commands.asadmin`). If the deploy commands are already found in that file, this script does nothing.
+- `${SCRIPTS_DIR}/startInForeground.sh`. This script starts the server in the foreground, in a manner that allows the Payara instance to be controlled by the docker host. The server will run the pre boot commands found in the file at `$PREBOOT_COMMANDS`, as well as the post boot commands found in the file at `$POSTBOOT_COMMANDS`.
 
-It's possible to run a custom set of asadmin commands by specifying the `POSTBOOT_COMMANDS` environment variable to point to the abslute path of the custom post boot command file. In that case, the default entry point won't deploy applications in `/opt/payara/deployments`, you will have to specify the deploy command(s) in your custom post boot command file.
+Because of the default entrypoint being unchanged, you can override the default instruction set to run any number of preparatory commands for testing. For example, the following command will start the container at a bash prompt, allowing you to browse the image and configure the Payara Server instance as you like:
 
-You may also want to completely redefine the default entry point with the `--entrypoint` argument of `docker run`.
+```
+docker run -p 8080:8080 -it payara/server-full bash
+```
+
+It's possible to run a custom set of asadmin commands either by specifying the `POSTBOOT_COMMANDS` environment variable to point to the absolute path of the custom post boot command file, or by providing a custom file located at `$POSTBOOT_COMMANDS` (default `$CONFIG_DIR/post-boot-commands.asadmin`).
+
+## Environment Variables
+
+The following environment variables are available to be used. When edited either in a `Dockerfile` or before the `startInForeground.sh` script is ran, they will change the behaviour of the Payara Server instance.
+
+- `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `startInForeground.sh` script.
+- `DEPLOY_PROPS` - Specifies a list of properties to be passed with the deploy commands generated in the `generate_deploy_commands.sh` script, For example `'--properties=implicitCdiEnabled=false'`.
+- `POSTBOOT_COMMANDS` - The name of the file containing post boot commands for the Payara Server instance. This is the file written to in the `generate_deploy_commands.sh` script.
+- `PREBOOT_COMMANDS` - The name of the file containing pre boot commands for the Payara Server instance.
+
+The following environment variables shouldn't be changed, but may be helpful in your Dockerfile.
+
+|  Variable name  |           Value            | Description |
+| --------------- | -------------------------- | ----------- |
+| `HOME_DIR`      | `/opt/payara`              | The home directory for the `payara` user |
+| `PAYARA_DIR`    | `/opt/payara/appserver`    | The root directory of the Payara installation |
+| `SCRIPT_DIR`    | `/opt/payara/scripts`      | The directory where the `generate_deploy_commands.sh` and `startInForeground.sh` scripts can be found. |
+| `CONFIG_DIR`    | `/opt/payara/config`       | The directory where the post and pre boot files are generated to by default. |
+| `DEPLOY_DIR`    | `/opt/payara/deployments`  | The directory where applications are searched for in `generate_deploy_commands.sh` script. |
+| `PASSWORD_FILE` | `/opt/payara/passwordFile` | The location of the password file for asadmin. This can be passed to asadmin using the `--passwordfile` parameter. |
 
 # Details
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ docker run -p 8080:8080 mycompany/myapplication
 
 The default entry point is `/bin/bash` as per the docker default. The default `CMD` command runs the following scripts:
 
-- `${SCRIPTS_DIR}/generate_deploy_commands.sh`. This script outputs deploy commands to the post boot command file located at `$POSTBOOT_COMMANDS` (default `$CONFIG_DIR/post-boot-commands.asadmin`). If the deploy commands are already found in that file, this script does nothing.
-- `${SCRIPTS_DIR}/startInForeground.sh`. This script starts the server in the foreground, in a manner that allows the Payara instance to be controlled by the docker host. The server will run the pre boot commands found in the file at `$PREBOOT_COMMANDS`, as well as the post boot commands found in the file at `$POSTBOOT_COMMANDS`.
+- `${SCRIPT_DIR}/generate_deploy_commands.sh`. This script outputs deploy commands to the post boot command file located at `$POSTBOOT_COMMANDS` (default `$CONFIG_DIR/post-boot-commands.asadmin`). If the deploy commands are already found in that file, this script does nothing.
+- `${SCRIPT_DIR}/startInForeground.sh`. This script starts the server in the foreground, in a manner that allows the Payara instance to be controlled by the docker host. The server will run the pre boot commands found in the file at `$PREBOOT_COMMANDS`, as well as the post boot commands found in the file at `$POSTBOOT_COMMANDS`.
 
 Because of the default entrypoint being unchanged, you can override the default instruction set to run any number of preparatory commands for testing. For example, the following command will start the container at a bash prompt, allowing you to browse the image and configure the Payara Server instance as you like:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To boot the default domain with HTTP listener exported on port 8080:
 docker run -p 8080:8080 payara/server-full
 ```
 
-The Docker container specifies the default entry point, which starts a custom domain `docker-domain` in foreground so that Payara Server becomes the main process.
+The Docker container specifies the default entry point, which starts a custom domain `production` in foreground so that Payara Server becomes the main process.
 
 ## Open ports
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following environment variables are available to be used. When edited either
 - `DEPLOY_PROPS` - Specifies a list of properties to be passed with the deploy commands generated in the `generate_deploy_commands.sh` script, For example `'--properties=implicitCdiEnabled=false'`.
 - `POSTBOOT_COMMANDS` - The name of the file containing post boot commands for the Payara Server instance. This is the file written to in the `generate_deploy_commands.sh` script.
 - `PREBOOT_COMMANDS` - The name of the file containing pre boot commands for the Payara Server instance.
+- `AS_ADMIN_MASTERPASSWORD` - The master password to pass to Payara Server. This is overriden if one is specified in the `$PASSWORD_FILE`.
 
 The following environment variables shouldn't be changed, but may be helpful in your Dockerfile.
 

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -1,12 +1,13 @@
 ################################################################################
 #
-# A script to generate the $POSTBOOT_COMMANDS file with asadmin commands to deploy 
-# all applications in $DEPLOY_DIR (either files or folders). 
+# A script to append deploy commands to the post boot command file at
+# $PAYARA_HOME/scripts/post-boot-commands.asadmin file. All applications in the
+# $DEPLOY_DIR (either files or folders) will be deployed.
 # The $POSTBOOT_COMMANDS file can then be used with the start-domain using the
 #  --postbootcommandfile parameter to deploy applications on startup.
 #
 # Usage:
-# ./generate_deploy_commands.sh [deploy command parameters]
+# ./generate_deploy_commands.sh
 #
 # Optionally, any number of parameters of the asadmin deploy command can be 
 # specified as parameters to this script. 
@@ -18,24 +19,19 @@
 # a single application exists in the $DEPLOY_DIR directory.
 ################################################################################
 
-if [ x$1 != x ]
-  then
-    DEPLOY_OPTS="$DEPLOY_OPTS $*"
-fi
-
 # Create pre and post boot command files if they don't exist
 touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
 
 # RAR files first
-for deployment in $(find ${PAYARA_PATH}/deployments/ -name "*.rar");
+for deployment in $(find ${PAYARA_PATH}/deployments/ -maxdepth 1 -name "*.rar");
 do
 	echo "Adding deployment target $deployment to post boot commands";
 	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;
 done
 
-# Then everything else
-for deployment in $(find ${PAYARA_PATH}/deployments/ -name "*.war" -o -name "*.ear" -o -name "*.jar");
+# Then every other WAR, EAR, JAR or directory
+for deployment in $(find ${PAYARA_PATH}/deployments/ -maxdepth 1 ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d);
 do
 	echo "Adding deployment target $deployment to post boot commands";
 	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ################################################################################
 #
 # A script to append deploy commands to the post boot command file at

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -15,6 +15,10 @@
 #
 # ./generate_deploy_commands.sh --properties=implicitCdiEnabled=false
 #
+# Environment variables used:
+#   - $PREBOOT_COMMANDS - the pre boot command file.
+#   - $POSTBOOT_COMMANDS - the post boot command file.
+#
 # Note that many parameters to the deploy command can be safely used only when 
 # a single application exists in the $DEPLOY_DIR directory.
 ################################################################################

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -24,14 +24,14 @@ touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
 
 # RAR files first
-for deployment in $(find ${PAYARA_PATH}/deployments/ -maxdepth 1 -name "*.rar");
+for deployment in $(find ${PAYARA_PATH}/deployments/ -mindepth 1 -maxdepth 1 -name "*.rar");
 do
 	echo "Adding deployment target $deployment to post boot commands";
 	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;
 done
 
 # Then every other WAR, EAR, JAR or directory
-for deployment in $(find ${PAYARA_PATH}/deployments/ -maxdepth 1 ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d);
+for deployment in $(find ${PAYARA_PATH}/deployments/ -mindepth 1 -maxdepth 1 ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d);
 do
 	echo "Adding deployment target $deployment to post boot commands";
 	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -40,7 +40,7 @@ deploy() {
 		exit 1;
 	fi
 
-	DEPLOY_STATEMENT="deploy $DEPLOY_OPTS $1"
+	DEPLOY_STATEMENT="deploy $DEPLOY_PROPS $1"
 	if grep -q $1 $POSTBOOT_COMMANDS; then
 		echo "post boot commands already deploys $1";
 	else

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -24,6 +24,11 @@
 # a single application exists in the $DEPLOY_DIR directory.
 ################################################################################
 
+# Check required variables are set
+if [ -z $DEPLOY_DIR ]; then echo "Variable DEPLOY_DIR is not set."; exit 1; fi
+if [ -z $PREBOOT_COMMANDS ]; then echo "Variable PREBOOT_COMMANDS is not set."; exit 1; fi
+if [ -z $POSTBOOT_COMMANDS ]; then echo "Variable POSTBOOT_COMMANDS is not set."; exit 1; fi
+
 # Create pre and post boot command files if they don't exist
 touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
@@ -45,13 +50,13 @@ deploy() {
 }
 
 # RAR files first
-for deployment in $(find ${PAYARA_PATH}/deployments/ -mindepth 1 -maxdepth 1 -name "*.rar");
+for deployment in $(find $DEPLOY_DIR -mindepth 1 -maxdepth 1 -name "*.rar");
 do
 	deploy $deployment;
 done
 
 # Then every other WAR, EAR, JAR or directory
-for deployment in $(find ${PAYARA_PATH}/deployments/ -mindepth 1 -maxdepth 1 ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d);
+for deployment in $(find $DEPLOY_DIR -mindepth 1 -maxdepth 1 ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d);
 do
 	deploy $deployment;
 done

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -23,16 +23,30 @@
 touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
 
+deploy() {
+
+	if [ -z $1 ]; then
+		echo "No deployment specified";
+		exit 1;
+	fi
+
+	DEPLOY_STATEMENT="deploy $DEPLOY_OPTS $1"
+	if grep -q $1 $POSTBOOT_COMMANDS; then
+		echo "post boot commands already deploys $1";
+	else
+		echo "Adding deployment target $1 to post boot commands";
+		echo $DEPLOY_STATEMENT >> $POSTBOOT_COMMANDS;
+	fi
+}
+
 # RAR files first
 for deployment in $(find ${PAYARA_PATH}/deployments/ -mindepth 1 -maxdepth 1 -name "*.rar");
 do
-	echo "Adding deployment target $deployment to post boot commands";
-	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;
+	deploy $deployment;
 done
 
 # Then every other WAR, EAR, JAR or directory
 for deployment in $(find ${PAYARA_PATH}/deployments/ -mindepth 1 -maxdepth 1 ! -name "*.rar" -a -name "*.war" -o -name "*.ear" -o -name "*.jar" -o -type d);
 do
-	echo "Adding deployment target $deployment to post boot commands";
-	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;
+	deploy $deployment;
 done

--- a/bin/generate_deploy_commands.sh
+++ b/bin/generate_deploy_commands.sh
@@ -28,14 +28,14 @@ touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
 
 # RAR files first
-for deployment in $(find ${PAYARA_PATH}/deployments -name "*.rar");
+for deployment in $(find ${PAYARA_PATH}/deployments/ -name "*.rar");
 do
 	echo "Adding deployment target $deployment to post boot commands";
 	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;
 done
 
 # Then everything else
-for deployment in $(find ${PAYARA_PATH}/deployments -name "*.war" -o -name "*.ear" -o -name "*.jar");
+for deployment in $(find ${PAYARA_PATH}/deployments/ -name "*.war" -o -name "*.ear" -o -name "*.jar");
 do
 	echo "Adding deployment target $deployment to post boot commands";
 	echo "deploy $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS;

--- a/bin/startInForeground.sh
+++ b/bin/startInForeground.sh
@@ -35,7 +35,7 @@
 touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
 
-OUTPUT=`~/appserver/bin/asadmin start-domain --user $ADMIN_USER --passwordfile="/opt/payara/passwordFile" --dry-run --prebootcommandfile=$PREBOOT_COMMANDS --postbootcommandfile $POSTBOOT_COMMANDS $@ $DOMAIN_NAME`
+OUTPUT=`~/appserver/bin/asadmin --user $ADMIN_USER --passwordfile="/opt/payara/passwordFile" start-domain --dry-run --prebootcommandfile=$PREBOOT_COMMANDS --postbootcommandfile $POSTBOOT_COMMANDS $@ $DOMAIN_NAME`
 STATUS=$?
 if [ "$STATUS" -ne 0 ]
   then

--- a/bin/startInForeground.sh
+++ b/bin/startInForeground.sh
@@ -12,27 +12,18 @@
 #
 # It's possible to use any arguments of the start-domain command as arguments to startInForeground.sh
 #
-# If the first argument to this script starts with --passwordfile= it should specify the path to the 
-# password file that contains the master password. Passwodfile can be also set using PASSWORD_FILE 
-# environment variable. Alternatively, master password can be set using AS_ADMIN_MASTERPASSWORD environment 
-# variable.
+# Environment variables used:
+#   - $ADMIN_USER - the username to use for the asadmin utility.
+#   - $PASSWORD_FILE - the password file to use for the asadmin utility.
+#   - $PREBOOT_COMMANDS - the pre boot command file.
+#   - $POSTBOOT_COMMANDS - the post boot command file.
+#   - $DOMAIN_NAME - the name of the domain to start.
+#   - $JVM_ARGS - extra JVM options to pass to the Payara Server instance.
+#   - $AS_ADMIN_MASTERPASSWORD - the master password for the Payara Server instance.
 #
-# By default, this script executes the asadmin tool which is found in the same directory. 
-# The AS_ADMIN_PATH environment variable can be used to specify an alternative path to the asadmin tool.
+# This script executes the asadmin tool which is expected at ~/appserver/bin/asadmin.
 #
 ##########################################################################################################
-
-if [ -z "$AS_ADMIN_PATH" ]
-  then
-    AS_ADMIN_PATH=`dirname $0`/asadmin
-fi
-
-if echo "$1" | grep -e '--passwordfile=' > /dev/null
-  then
-    PASSWORD_FILE=`echo "$1" | sed 's/--passwordfile=//'`
-    PASSWORD_FILE_ARG="$1"
-    shift 1
-fi
 
 # The following command gets the command line to be executed by start-domain
 # - print the command line to the server with --dry-run, each argument on a separate line
@@ -40,7 +31,11 @@ fi
 # - surround each line except with parenthesis to allow spaces in paths
 # - remove lines before and after the command line and squash commands on a single line
 
-OUTPUT=`"$AS_ADMIN_PATH" start-domain "$PASSWORD_FILE_ARG" --dry-run "$@"`
+# Create pre and post boot command files if they don't exist
+touch $POSTBOOT_COMMANDS
+touch $PREBOOT_COMMANDS
+
+OUTPUT=`~/appserver/bin/asadmin start-domain --passwordfile="/opt/payara/passwordFile" --dry-run --prebootcommandfile=$PREBOOT_COMMANDS --postbootcommandfile $POSTBOOT_COMMANDS $@ $DOMAIN_NAME`
 STATUS=$?
 if [ "$STATUS" -ne 0 ]
   then

--- a/bin/startInForeground.sh
+++ b/bin/startInForeground.sh
@@ -25,6 +25,13 @@
 #
 ##########################################################################################################
 
+# Check required variables are set
+if [ -z $ADMIN_USER ]; then echo "Variable ADMIN_USER is not set."; exit 1; fi
+if [ -z $PASSWORD_FILE ]; then echo "Variable PASSWORD_FILE is not set."; exit 1; fi
+if [ -z $PREBOOT_COMMANDS ]; then echo "Variable PREBOOT_COMMANDS is not set."; exit 1; fi
+if [ -z $POSTBOOT_COMMANDS ]; then echo "Variable POSTBOOT_COMMANDS is not set."; exit 1; fi
+if [ -z $DOMAIN_NAME ]; then echo "Variable DOMAIN_NAME is not set."; exit 1; fi
+
 # The following command gets the command line to be executed by start-domain
 # - print the command line to the server with --dry-run, each argument on a separate line
 # - remove -read-string argument
@@ -35,7 +42,7 @@
 touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
 
-OUTPUT=`~/appserver/bin/asadmin --user $ADMIN_USER --passwordfile="/opt/payara/passwordFile" start-domain --dry-run --prebootcommandfile=$PREBOOT_COMMANDS --postbootcommandfile $POSTBOOT_COMMANDS $@ $DOMAIN_NAME`
+OUTPUT=`${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain --dry-run --prebootcommandfile=${PREBOOT_COMMANDS} --postbootcommandfile=${POSTBOOT_COMMANDS} $@ $DOMAIN_NAME`
 STATUS=$?
 if [ "$STATUS" -ne 0 ]
   then
@@ -63,4 +70,4 @@ if test "$AS_ADMIN_MASTERPASSWORD"x = x
     AS_ADMIN_MASTERPASSWORD=changeit
 fi
 echo "AS_ADMIN_MASTERPASSWORD=$AS_ADMIN_MASTERPASSWORD" > /tmp/masterpwdfile
-exec $COMMAND < /tmp/masterpwdfile
+exec ${COMMAND} < /tmp/masterpwdfile

--- a/bin/startInForeground.sh
+++ b/bin/startInForeground.sh
@@ -35,7 +35,7 @@
 touch $POSTBOOT_COMMANDS
 touch $PREBOOT_COMMANDS
 
-OUTPUT=`~/appserver/bin/asadmin start-domain --passwordfile="/opt/payara/passwordFile" --dry-run --prebootcommandfile=$PREBOOT_COMMANDS --postbootcommandfile $POSTBOOT_COMMANDS $@ $DOMAIN_NAME`
+OUTPUT=`~/appserver/bin/asadmin start-domain --user $ADMIN_USER --passwordfile="/opt/payara/passwordFile" --dry-run --prebootcommandfile=$PREBOOT_COMMANDS --postbootcommandfile $POSTBOOT_COMMANDS $@ $DOMAIN_NAME`
 STATUS=$?
 if [ "$STATUS" -ne 0 ]
   then
@@ -43,7 +43,9 @@ if [ "$STATUS" -ne 0 ]
     exit 1
 fi
 
-COMMAND=`echo "$OUTPUT" | sed -n -e '2,/^$/p'`
+COMMAND=`echo "$OUTPUT"\
+ | sed -n -e '2,/^$/p'\
+ | sed 's/glassfish.jar/glassfish.jar '"$JVM_ARGS"'/' `
 
 echo Executing Payara Server with the following command line:
 echo $COMMAND | tr ' ' '\n'


### PR DESCRIPTION
- Minimised layer count and organised by least-most likely to change.
- Download from maven central instead of search.maven.org.
- Changed JDK version to 171 to prevent the ALPN error.
- Removed domain1 in favour of the `production` domain.
- Configured domain to use CGroup memory defaults instead of hard coded `-Xmx` and `-Xms` values.
- Fixed deploy script to deploy RAR files first, followed by all EAR, JAR, WAR files as well as directories.
- Allowed custom JVM arguments using the `JVM_ARGS` environment variable.
- Disabled logging to a file.
- Fixed cases where post boot command file was already written to, or in a different location.
- Re-arranged directories to be more intuitive.
- Changed script arguments from arguments to the declared environment variables. This makes it easier to call them manually (no required arguments).
- Moved entrypoint to CMD.

I've updated all the notable changes in the README.