### PR TITLE
Allow debugging to be switched on easily for domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV HOME_DIR=/opt/payara\
     ADMIN_PASSWORD=admin \
     # Utility environment variables
     JVM_ARGS=\
+    PAYARA_ARGS=\
     DEPLOY_PROPS=\
     POSTBOOT_COMMANDS=/opt/payara/config/post-boot-commands.asadmin\
     PREBOOT_COMMANDS=/opt/payara/config/pre-boot-commands.asadmin

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -9,4 +9,4 @@ for f in ${SCRIPT_DIR}/init_* ${SCRIPT_DIR}/init.d/*; do
       echo
 done
 
-exec ${SCRIPT_DIR}/startInForeground.sh $@
+exec ${SCRIPT_DIR}/startInForeground.sh $PAYARA_ARGS

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -9,4 +9,4 @@ for f in ${SCRIPT_DIR}/init_* ${SCRIPT_DIR}/init.d/*; do
       echo
 done
 
-exec ${SCRIPT_DIR}/startInForeground.sh
+exec ${SCRIPT_DIR}/startInForeground.sh $@


### PR DESCRIPTION
The only answers I had found to this problem were to call the startInForeground.sh script directly from the entrypoint. However, I need to run scripts in the init.d folder before starting the domain. So I created a new environment variable called PAYARA_ARGS, which is passed through from entrypoint.sh into the startInForeground.sh script. I could have used this directly in the script, but since it was already appending parameters to the generated command, I thought this was neater.

I have tested this by starting the image with a docker-compose file where the environment variable is set: PAYARA_ARGS=-d. The server starts up in debug mode and I can remotely attach to it using netbeans.