### PR TITLE
Enable disabling logging to file after the blocking fix was implemented

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,7 @@ RUN wget --no-verbose -O payara.zip ${PAYARA_PKG} && \
     done && \
     # FIXME: when upgrading this container to Java 10+, this needs to be changed to '-XX:+UseContainerSupport' and '-XX:MaxRAMPercentage'
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options '-XX\:+UnlockExperimentalVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:MaxRAMFraction=1' && \
-    # FIXME: waiting on fix to https://github.com/payara/Payara/issues/3506
-    #${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} && \
     # Cleanup unused files
     rm -rf \


### PR DESCRIPTION
The fix is implemented in 5.193. The 5.193 image was released without this, we may want to backport this to 5.193.