### PR TITLE
Change sed to use "|" instead of "/" for JVM_ARGS

### DIFF
--- a/bin/startInForeground.sh
+++ b/bin/startInForeground.sh
@@ -52,7 +52,7 @@ fi
 
 COMMAND=`echo "$OUTPUT"\
  | sed -n -e '2,/^$/p'\
- | sed 's/glassfish.jar/glassfish.jar '"$JVM_ARGS"'/' `
+ | sed "s|glassfish.jar|glassfish.jar $JVM_ARGS |g"`
 
 echo Executing Payara Server with the following command line:
 echo $COMMAND | tr ' ' '\n'


### PR DESCRIPTION
JVM arguments with file paths as the value are interpreted as part of the sed command.
For example, JVM_ARGS="-Dlogback.configurationFile=/opt/payara/config/logback.xml" will cause sed to fail with "unknown option to `s'".