### PR TITLE
Tune memory configuration with container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV HOME_DIR=/opt/payara\
     ADMIN_USER=admin\
     ADMIN_PASSWORD=admin \
     # Utility environment variables
+    MAX_RAM_PERCENTAGE=25.00\
     JVM_ARGS=\
     PAYARA_ARGS=\
     DEPLOY_PROPS=\
@@ -70,6 +71,7 @@ RUN wget --no-verbose -O payara.zip ${PAYARA_PKG} && \
     for MEMORY_JVM_OPTION in $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]"); do\
         ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} delete-jvm-options $MEMORY_JVM_OPTION;\
     done && \
+    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options '-XX\:MaxRAMPercentage=${ENV=MAX_RAM_PERCENTAGE}' && \
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} && \
     # Cleanup unused files

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,6 @@ RUN wget --no-verbose -O payara.zip ${PAYARA_PKG} && \
     for MEMORY_JVM_OPTION in $(${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} list-jvm-options | grep "Xm[sx]"); do\
         ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} delete-jvm-options $MEMORY_JVM_OPTION;\
     done && \
-    # FIXME: when upgrading this container to Java 10+, this needs to be changed to '-XX:+UseContainerSupport' and '-XX:MaxRAMPercentage'
-    ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} create-jvm-options '-XX\:+UnlockExperimentalVMOptions:-XX\:+UseCGroupMemoryLimitForHeap:-XX\:MaxRAMFraction=1' && \
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=false && \
     ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME} && \
     # Cleanup unused files


### PR DESCRIPTION
As outlined in #70, since we are on a JDK 8u191+ now, let's make use of the backported container support.

This PR simply deletes the JVM options related to memory handling, as the container support is enabled by default in recent JDK releases.

Instead, I added an env var that allows tuning for the `MaxRAMPercentage` setting. It defaults to 25%, which is the very same as set without the option.

I based this to the 5.201 branch, as it would be great to see this in this just released version (see also my comment in #117). I'm happy to rebase to `master` or create another PR. Whatever suits your needs, as long as it will be also in `5.201` tag on Docker Hub :wink: 

## More details
To see the difference I made a simple comparison on a K8s container running on Docker with a 4 GiB RAM limit:
![image](https://user-images.githubusercontent.com/5468333/75661839-5a568900-5c6e-11ea-950f-531664d40009.png)

The new native container support allows for a much better fine tuning of heap space, for example allowing [Dataverse](https://github.com/IQSS/dataverse-kubernetes) to be run in a 1 Gib pod using 50% heap, which is very useful for dev purposes:
![image](https://user-images.githubusercontent.com/5468333/75664734-3fd2de80-5c73-11ea-97d1-c0dfc46ba658.png)

![image](https://user-images.githubusercontent.com/5468333/75664632-0f8b4000-5c73-11ea-88f9-6b4c501813c8.png)


See also 
- https://merikan.com/2019/04/jvm-in-a-container
- https://www.ccampo.me/java/docker/containers/kubernetes/2019/10/31/java-in-a-container.html